### PR TITLE
fix format_err_str function in mytorch.py

### DIFF
--- a/co/mytorch.py
+++ b/co/mytorch.py
@@ -542,7 +542,10 @@ class Worker(object):
     def format_err_str(self, errs, div=1):
         err_list = []
         for v in errs.values():
-            if isinstance(v, (list, np.ndarray)):
+            if isinstance(v, np.ndarray):
+                err_list.extend(v.ravel())
+            elif isinstance(v, list):
+                v=np.array(v)
                 err_list.extend(v.ravel())
             else:
                 err_list.append(v)


### PR DESCRIPTION
Hey, Thanks for your help and I succeed in run it.
But there may exist some little bug.
I try to fix this error `type: list has no attribute ravel`.
The error raises if we run the following:
`python exp.py --net rnn_vgg16unet3_gruunet4.64.3 --cmd eval --iter last --eval-dsets tat-subseq --eval-scale 0.5`
Only np array has attribute `ravel`. But `isinstance(v, (np.ndarray, list))` make list operate `list.ravel` which will cause error.

Sorry for me can't provide the snapshot because I  get off work and forget to save.